### PR TITLE
Remove buffer length limit and removed decodeEntities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Gulp-utm2html is a tool that will help add UTM tags to URL in HTML file. I use this plugin to make URL with UTM tags in my HTML emails. 
+Gulp-utm2html is a tool that will help add UTM tags to URL in HTML file. I use this plugin to make URL with UTM tags in my HTML emails.
 
 ##Usage
 
@@ -44,6 +44,8 @@ URL with mailto protocol will be ignored. If your URL already have UTM tags they
 	UTM tags will be saved.</a>
 <a href="mailto:n.litvin41@gmail.com">
 	URL with mailto protocol will be ignored.</a>
+<a href="tel:07700900000">
+	URL with tel protocol will be ignored.</a>
 ```
 
 This code will compiled to this:
@@ -59,6 +61,8 @@ This code will compiled to this:
 	UTM tags will be saved.</a>
 <a href="mailto:n.litvin41@gmail.com">
 	URL with mailto protocol will be ignored.</a>
+<a href="tel:07700900000">
+	URL with tel protocol will be ignored.</a>
 ```
 
 MIT License

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function utm2html(opts) {
 
         if (file.isBuffer()) {
 
-            var $ = cheerio.load(file.contents); // load in the HTML into cheerio
+          var $ = cheerio.load(file.contents, {decodeEntities: false}); // load in the HTML into cheerio
             var links = $('a');
 
             var preventChangesWords = ['nope', 'ignore', 'false'];
@@ -84,7 +84,7 @@ function utm2html(opts) {
             }
 
             var data = $.html();
-            var buffer = new Buffer(data.length);
+            var buffer = new Buffer(data);
             buffer.write(data);
             file.contents = buffer;
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function utm2html(opts) {
 
         if (file.isBuffer()) {
 
-          var $ = cheerio.load(file.contents, {decodeEntities: false}); // load in the HTML into cheerio
+            var $ = cheerio.load(file.contents, {decodeEntities: false}); // load in the HTML into cheerio
             var links = $('a');
 
             var preventChangesWords = ['nope', 'ignore', 'false'];

--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ function utm2html(opts) {
                 if (parsedLink.protocol === 'mailto:') {
                     continue;
                 }
+                // ignore URL with tel protocol
+                else if (parsedLink.protocol === 'tel:') {
+                    continue;
+                }
 
                 parsedLink.query.utm_source      = opts.source;
                 parsedLink.query.utm_medium      = opts.medium;


### PR DESCRIPTION
I have removed the data._length_ to stop the HTML file being clipped. 

I altered the cheerio.load to not decodeEntities. So the URL with tracking added is:
`?utm_source=in-house&utm_medium=email&utm_campaign=name`

and not:
`?utm_source=in-house&amp;utm_medium=email&amp;utm_campaign=name`

I have also added an ignore for the "tel:" URL's. I don't know if it would be better to only work on a URL id it is http:// or https:// 